### PR TITLE
Raised minimum mouse movement seed limit for more entropy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4998,6 +4998,9 @@
 			// number of mouse movements to wait for
 			seedLimit: (function () {
 				var num = Crypto.util.randomBytes(12)[11];
+				if(num < 96) {
+					num = num*2;
+				}
 				return 50 + Math.floor(num);
 			})(),
 


### PR DESCRIPTION
If the `seedLimit` has decided to use less than 96 mouse movement seeds, double it.

```
seedLimit = 47 ... seedLimit = 94
seedLimit = 102 ... seedLimit = 102
```

This adds more random entropy to the seeder.
