### PR TITLE
Fixed strange comma causing syntax error and breaking flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -5481,7 +5481,7 @@
 					"detaillabelprivhex": "Clé privée Format Hexadecimal (64 caractères [0-9A-F]) :",
 					"detaillabelprivb64": "Clé privée Base64 (44 caractères) :",
 					"detaillabelprivmini": "Clé privée Format Mini (22, 26 ou 30 caractères, débute par un 'S') :"
-				}，
+				},
 				"zh-cn": {
 					// javascript alerts or messages
 					"testneteditionactivated": "已启动测试模式",


### PR DESCRIPTION
I was messing with the bulk generator and noticed that no keys were being generated.

The JS console gave me a syntax error due to a strange comma being used in the "zh-cn" translation commit.

```
Uncaught SyntaxError: Unexpected token ILLEGAL        (index):5484
```

I'm not sure why but it looks like a different comma that JS doesn't parse properly and so it causes a syntax error.

Changing it to an "english" comma fixes the issue and the bulk generator works fine.
